### PR TITLE
fix(enrich): resolve GeoIP search paths with os.UserHomeDir

### DIFF
--- a/pkg/enrich/geoip.go
+++ b/pkg/enrich/geoip.go
@@ -82,9 +82,9 @@ var geoIPSearchPaths = []string{
 	"GeoLite2-Country.mmdb",
 	"dbip-country-lite.mmdb",
 	"dbip-city-lite.mmdb",
-	filepath.Join(os.Getenv("HOME"), ".config", "caddy-analyzer", "GeoIP.mmdb"),
-	filepath.Join(os.Getenv("HOME"), ".config", "caddy-analyzer", "GeoLite2-Country.mmdb"),
-	filepath.Join(os.Getenv("HOME"), ".config", "caddy-analyzer", "dbip-country-lite.mmdb"),
+	filepath.Join(userHomeDir(), ".config", "caddy-analyzer", "GeoIP.mmdb"),
+	filepath.Join(userHomeDir(), ".config", "caddy-analyzer", "GeoLite2-Country.mmdb"),
+	filepath.Join(userHomeDir(), ".config", "caddy-analyzer", "dbip-country-lite.mmdb"),
 	"/var/lib/caddy-analyzer/GeoIP.mmdb",
 	"/var/lib/caddy-analyzer/GeoLite2-Country.mmdb",
 	"/usr/share/GeoIP/GeoIP.mmdb",
@@ -96,8 +96,8 @@ var geoIPSearchPaths = []string{
 var geoIPASNSearchPaths = []string{
 	"GeoLite2-ASN.mmdb",
 	"dbip-asn-lite.mmdb",
-	filepath.Join(os.Getenv("HOME"), ".config", "caddy-analyzer", "GeoLite2-ASN.mmdb"),
-	filepath.Join(os.Getenv("HOME"), ".config", "caddy-analyzer", "dbip-asn-lite.mmdb"),
+	filepath.Join(userHomeDir(), ".config", "caddy-analyzer", "GeoLite2-ASN.mmdb"),
+	filepath.Join(userHomeDir(), ".config", "caddy-analyzer", "dbip-asn-lite.mmdb"),
 	"/var/lib/caddy-analyzer/GeoLite2-ASN.mmdb",
 	"/usr/share/GeoIP/GeoLite2-ASN.mmdb",
 }
@@ -106,6 +106,18 @@ var geoIPASNSearchPaths = []string{
 // lite mmdb when no GeoIP file is found. Must be called before NewGeoIP.
 func SetAutoDownload(enabled bool) {
 	autoDownload = enabled
+}
+
+// userHomeDir returns the current user's home directory. It prefers
+// os.UserHomeDir (which is cross-platform, resolving the right directory on
+// Windows where the HOME environment variable is typically unset) and falls
+// back to HOME when the OS-specific lookup fails, preserving the previous
+// behaviour on systems where only HOME is defined.
+func userHomeDir() string {
+	if home, err := os.UserHomeDir(); err == nil && home != "" {
+		return home
+	}
+	return os.Getenv("HOME")
 }
 
 // userConfigDir returns the directory where auto-downloaded mmdb files

--- a/pkg/enrich/geoip_test.go
+++ b/pkg/enrich/geoip_test.go
@@ -1,0 +1,57 @@
+package enrich
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+// TestUserHomeDirResolvesNonEmpty asserts the cross-platform home lookup
+// returns a usable directory on the host running the tests (it must not
+// silently degrade to "" the way os.Getenv("HOME") does on Windows).
+func TestUserHomeDirResolvesNonEmpty(t *testing.T) {
+	home := userHomeDir()
+	if home == "" {
+		t.Fatalf("userHomeDir() returned empty; expected a resolved home directory on %s", runtime.GOOS)
+	}
+	if info, err := os.Stat(home); err != nil || !info.IsDir() {
+		t.Fatalf("userHomeDir()=%q is not an accessible directory: %v", home, err)
+	}
+}
+
+// TestGeoIPSearchPathsPrependUserHome asserts the home-based search paths are
+// built from userHomeDir() rather than the raw HOME env var, so they resolve
+// on Windows where HOME is typically unset.
+func TestGeoIPSearchPathsPrependUserHome(t *testing.T) {
+	home := userHomeDir()
+	wantCountry := []string{
+		filepath.Join(home, ".config", "caddy-analyzer", "GeoIP.mmdb"),
+		filepath.Join(home, ".config", "caddy-analyzer", "GeoLite2-Country.mmdb"),
+		filepath.Join(home, ".config", "caddy-analyzer", "dbip-country-lite.mmdb"),
+	}
+	for _, want := range wantCountry {
+		if !containsPath(geoIPSearchPaths, want) {
+			t.Errorf("geoIPSearchPaths missing %q; got %v", want, geoIPSearchPaths)
+		}
+	}
+
+	wantASN := []string{
+		filepath.Join(home, ".config", "caddy-analyzer", "GeoLite2-ASN.mmdb"),
+		filepath.Join(home, ".config", "caddy-analyzer", "dbip-asn-lite.mmdb"),
+	}
+	for _, want := range wantASN {
+		if !containsPath(geoIPASNSearchPaths, want) {
+			t.Errorf("geoIPASNSearchPaths missing %q; got %v", want, geoIPASNSearchPaths)
+		}
+	}
+}
+
+func containsPath(paths []string, want string) bool {
+	for _, p := range paths {
+		if p == want {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
Closes #22.

## What

- Adds a `userHomeDir()` helper in `pkg/enrich/geoip.go` that prefers `os.UserHomeDir()` and falls back to `os.Getenv("HOME")` when the OS-specific lookup fails.
- Replaces the five `os.Getenv("HOME")` calls in `geoIPSearchPaths` and `geoIPASNSearchPaths` with `userHomeDir()`.

## Why

`os.Getenv("HOME")` is typically unset on Windows, so the GeoIP/ASN search paths resolved to `/.config/caddy-analyzer/GeoIP.mmdb` instead of `C:\Users\<user>\.config\caddy-analyzer\...`, breaking cross-platform database discovery. `os.UserHomeDir()` is the stdlib cross-platform equivalent (it already backs the auto-download path via `userConfigDir()`/`os.UserConfigDir()` in the same file). The fallback to `HOME` preserves the previous behaviour on systems that only define `HOME`.

## Testing

- New `pkg/enrich/geoip_test.go`:
  - `TestUserHomeDirResolvesNonEmpty` — `userHomeDir()` returns an accessible home directory on the host.
  - `TestGeoIPSearchPathsPrependUserHome` — `geoIPSearchPaths` and `geoIPASNSearchPaths` contain the home-based entries built from `userHomeDir()`.
- `gofmt -l`, `go vet ./...`, and `go test -race ./...` are all green locally (full suite passes).
- No `.github/workflows/*.yml` files were modified.