### PR TITLE
fix(sigma): derive rule UUIDs with UUIDv5 instead of MD5

### DIFF
--- a/cmd/export_sigma.go
+++ b/cmd/export_sigma.go
@@ -1,16 +1,21 @@
 package cmd
 
 import (
-	"crypto/md5"
 	"fmt"
 	"io"
 	"os"
 	"strings"
 
+	"github.com/google/uuid"
 	"github.com/spf13/cobra"
 
 	"github.com/lenny-ts/caddy-analyzer/pkg/analysis"
 )
+
+// sigmaNamespace is the fixed namespace UUID used to derive deterministic
+// UUIDv5 identifiers for exported Sigma rules. It is generated once and must
+// never change, otherwise existing rules would receive new UUIDs on every run.
+var sigmaNamespace = uuid.MustParse("d17af9d5-d714-40a0-a935-8bc80b980109")
 
 var exportSigmaCmd = &cobra.Command{
 	Use:   "export-sigma [output-file]",
@@ -193,9 +198,7 @@ func writeSigmaRule(w io.Writer, r analysis.SigmaRuleInfo) error {
 }
 
 func sigmaUUID(title string) string {
-	h := md5.Sum([]byte("caddy-analyzer:sigma:" + title))
-	return fmt.Sprintf("%08x-%04x-%04x-%04x-%012x",
-		h[0:4], h[4:6], h[6:8], h[8:10], h[10:16])
+	return uuid.NewSHA1(sigmaNamespace, []byte("caddy-analyzer:sigma:"+title)).String()
 }
 
 func yamlEscape(s string) string {

--- a/cmd/export_sigma_test.go
+++ b/cmd/export_sigma_test.go
@@ -1,0 +1,56 @@
+package cmd
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/google/uuid"
+)
+
+// uuidPattern matches the canonical 8-4-4-4-12 lowercase UUID string format
+// that Sigma rule id fields expect.
+var uuidPattern = regexp.MustCompile(`^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$`)
+
+func TestSigmaUUIDFormat(t *testing.T) {
+	got := sigmaUUID("Excessive 4xx Errors from Single IP")
+	if !uuidPattern.MatchString(got) {
+		t.Fatalf("sigmaUUID returned %q, expected canonical UUIDv5 format", got)
+	}
+}
+
+func TestSigmaUUIDIsUUIDv5(t *testing.T) {
+	got := sigmaUUID("Excessive 4xx Errors from Single IP")
+	u, err := uuid.Parse(got)
+	if err != nil {
+		t.Fatalf("sigmaUUID returned %q which is not a valid UUID: %v", got, err)
+	}
+	if u.Version() != 5 {
+		t.Fatalf("sigmaUUID returned UUID version %d, expected version 5 (SHA-1)", u.Version())
+	}
+}
+
+func TestSigmaUUIDDeterministic(t *testing.T) {
+	title := "Geo-based Anomaly Detection"
+	first := sigmaUUID(title)
+	for i := 0; i < 5; i++ {
+		if got := sigmaUUID(title); got != first {
+			t.Fatalf("sigmaUUID is not deterministic: got %q, want %q", got, first)
+		}
+	}
+}
+
+func TestSigmaUUIDDistinctForDifferentTitles(t *testing.T) {
+	a := sigmaUUID("Rule A")
+	b := sigmaUUID("Rule B")
+	if a == b {
+		t.Fatalf("expected distinct UUIDs for distinct titles, both were %q", a)
+	}
+}
+
+func TestSigmaUUIDMatchesNamespaceDerivation(t *testing.T) {
+	title := "Excessive 4xx Errors from Single IP"
+	want := uuid.NewSHA1(sigmaNamespace, []byte("caddy-analyzer:sigma:"+title)).String()
+	if got := sigmaUUID(title); got != want {
+		t.Fatalf("sigmaUUID = %q, want %q", got, want)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -21,6 +21,7 @@ require (
 	github.com/clipperhouse/stringish v0.1.1 // indirect
 	github.com/clipperhouse/uax29/v2 v2.5.0 // indirect
 	github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f // indirect
+	github.com/google/uuid v1.6.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/lucasb-eyer/go-colorful v1.3.0 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect

--- a/go.sum
+++ b/go.sum
@@ -30,6 +30,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f h1:Y/CXytFA4m6baUTXGLOoWe4PQhGxaX0KpnayAqC48p4=
 github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f/go.mod h1:vw97MGsxSvLiUE2X8qFplwetxpGLQrlU1Q9AUEIzCaM=
+github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
+github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/lucasb-eyer/go-colorful v1.3.0 h1:2/yBRLdWBZKrf7gB40FoiKfAWYQ0lqNcbuQwVHXptag=


### PR DESCRIPTION
Sigma rule UUIDs were derived with MD5 (`crypto/md5`), which is deprecated for security-adjacent use. Sigma's convention is UUIDv5 (SHA-1, namespaced), as noted in #23.

## What changed

`cmd/export_sigma.go`:

- Replaced the MD5-based `sigmaUUID` derivation with `uuid.NewSHA1(sigmaNamespace, []byte("caddy-analyzer:sigma:"+title))`.
- Added a fixed namespace UUID, hardcoded as a `var` so it never changes between runs (changing it would re-key every existing rule):
  ```go
  var sigmaNamespace = uuid.MustParse("d17af9d5-d714-40a0-a935-8bc80b980109")
  ```
- Removed the now-unused `crypto/md5` import.

`go.mod` / `go.sum`:

- Added `github.com/google/uuid v1.6.0` (not previously present).

`cmd/export_sigma_test.go` (new):

- `TestSigmaUUIDFormat` — output is a canonical lowercase `8-4-4-4-12` UUID string.
- `TestSigmaUUIDIsUUIDv5` — parsed UUID reports version 5.
- `TestSigmaUUIDDeterministic` — same title yields the same UUID across repeated calls.
- `TestSigmaUUIDDistinctForDifferentTitles` — distinct titles yield distinct UUIDs.
- `TestSigmaUUIDMatchesNamespaceDerivation` — output matches `uuid.NewSHA1(sigmaNamespace, ...)`.

## Output format preserved

The previous code formatted the MD5 bytes as `%08x-%04x-%04x-%04x-%012x`, i.e. a lowercase dashed UUID-shaped string. `uuid.NewSHA1(...).String()` produces the same canonical lowercase `8-4-4-4-12` layout, so downstream Sigma rule consumers see the same shape — only the derived value changes (once, from the MD5-derived value to the UUIDv5-derived value for each rule).

## Verification

`go build ./...`, `go vet ./...`, `go test ./...` all pass. `gofmt -l` clean.

The namespace UUID `d17af9d5-d714-40a0-a935-8bc80b980109` is a one-time-generated literal committed as a constant; it is not computed at runtime.

Refs #23