### PR TITLE
Use shared formatter for zero duration deltas

### DIFF
--- a/cmd/diff.go
+++ b/cmd/diff.go
@@ -204,5 +204,5 @@ func formatDurationDelta(d float64) string {
 	if d < 0 {
 		return styleDiffGood.Render("-" + output.FormatDuration(-d))
 	}
-	return "0ms"
+	return output.FormatDuration(d)
 }

--- a/cmd/diff_test.go
+++ b/cmd/diff_test.go
@@ -1,0 +1,9 @@
+package cmd
+
+import "testing"
+
+func TestFormatDurationDeltaZero(t *testing.T) {
+	if got, want := formatDurationDelta(0), "N/A"; got != want {
+		t.Fatalf("formatDurationDelta(0) = %q, want %q", got, want)
+	}
+}


### PR DESCRIPTION
## Summary

- use `output.FormatDuration` for zero latency deltas
- add a regression test covering the zero-delta output

Closes #45

## Tests

- `go test ./...`
- `go vet ./...`
- `go build ./...`
- `go test -race ./...` could not run locally because the portable Windows toolchain requires CGO and no C compiler is installed