### PR TITLE
Remove yamlQuote, an exact copy of yamlEscape

### DIFF
--- a/cmd/export_sigma.go
+++ b/cmd/export_sigma.go
@@ -104,7 +104,7 @@ func writeSigmaRule(w io.Writer, r analysis.SigmaRuleInfo) error {
 			return err
 		}
 		for _, p := range r.URIPatterns {
-			if err := writef("        uri|re: %s\n", yamlQuote(p)); err != nil {
+			if err := writef("        uri|re: %s\n", yamlEscape(p)); err != nil {
 				return err
 			}
 		}
@@ -115,7 +115,7 @@ func writeSigmaRule(w io.Writer, r analysis.SigmaRuleInfo) error {
 			return err
 		}
 		for _, p := range r.UAPatterns {
-			if err := writef("        user_agent|re: %s\n", yamlQuote(p)); err != nil {
+			if err := writef("        user_agent|re: %s\n", yamlEscape(p)); err != nil {
 				return err
 			}
 		}
@@ -126,7 +126,7 @@ func writeSigmaRule(w io.Writer, r analysis.SigmaRuleInfo) error {
 			return err
 		}
 		for _, p := range r.AuthPatterns {
-			if err := writef("        authorization|re: %s\n", yamlQuote(p)); err != nil {
+			if err := writef("        authorization|re: %s\n", yamlEscape(p)); err != nil {
 				return err
 			}
 		}
@@ -137,7 +137,7 @@ func writeSigmaRule(w io.Writer, r analysis.SigmaRuleInfo) error {
 			return err
 		}
 		for _, p := range r.RawPatterns {
-			if err := writef("        raw_uri|re: %s\n", yamlQuote(p)); err != nil {
+			if err := writef("        raw_uri|re: %s\n", yamlEscape(p)); err != nil {
 				return err
 			}
 		}
@@ -199,12 +199,6 @@ func sigmaUUID(title string) string {
 }
 
 func yamlEscape(s string) string {
-	s = strings.ReplaceAll(s, `\`, `\\`)
-	s = strings.ReplaceAll(s, `"`, `\"`)
-	return `"` + s + `"`
-}
-
-func yamlQuote(s string) string {
 	s = strings.ReplaceAll(s, `\`, `\\`)
 	s = strings.ReplaceAll(s, `"`, `\"`)
 	return `"` + s + `"`


### PR DESCRIPTION
Closes #38

`yamlEscape` and `yamlQuote` in `cmd/export_sigma.go` were byte-for-byte identical — same two `strings.ReplaceAll` calls in the same order, same wrapping quotes. `yamlQuote` is gone and its four call sites (the `uri|re`, `user_agent|re`, `authorization|re` and `raw_uri|re` pattern lines) now call `yamlEscape`.

`yamlEscape` is the one kept because it was already the function the non-pattern fields used (`title`, `description`, and the falsepositives list), so this leaves every field in a Sigma rule escaped by the same call rather than by two names for it.

Byte-identical bodies mean the emitted YAML cannot change; the diff is a rename at four call sites plus the deleted function.

### Verification

```
go build ./...      # clean
go vet ./...        # clean
go test ./...       # all packages ok, incl. ./cmd (31s)
gofmt -l cmd/export_sigma.go   # no output
```