### PR TITLE
Merge validateIPOrCIDR into validateIP

### DIFF
--- a/cmd/ip.go
+++ b/cmd/ip.go
@@ -6,12 +6,17 @@ import (
 	"strings"
 )
 
+// validateIP accepts a bare IP address or a CIDR block, and rejects empty
+// input and anything that looks like a flag. Used both to fail fast on a
+// typo'd --ip / --exclude-ip filter -- which would otherwise surface as "no
+// log entries found" when the CIDR fails to parse inside MatchEntry -- and to
+// keep a mistyped block/unban argument away from iptables.
 func validateIP(ip string) error {
 	if ip == "" {
 		return fmt.Errorf("empty IP")
 	}
 	if strings.HasPrefix(ip, "-") {
-		return fmt.Errorf("invalid IP %q: looks like a flag", ip)
+		return fmt.Errorf("invalid IP or CIDR %q: looks like a flag", ip)
 	}
 	if net.ParseIP(ip) != nil {
 		return nil
@@ -19,5 +24,5 @@ func validateIP(ip string) error {
 	if _, _, err := net.ParseCIDR(ip); err == nil {
 		return nil
 	}
-	return fmt.Errorf("invalid IP %q", ip)
+	return fmt.Errorf("invalid IP or CIDR %q", ip)
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"net"
 	"os"
 	"os/signal"
 	"path/filepath"
@@ -905,36 +904,17 @@ func buildFilters() (types.Filters, error) {
 	}
 
 	if flagIP != "" {
-		if err := validateIPOrCIDR(flagIP); err != nil {
-			return f, fmt.Errorf("invalid --ip %q: %w", flagIP, err)
+		if err := validateIP(flagIP); err != nil {
+			return f, fmt.Errorf("--ip: %w", err)
 		}
 	}
 	if flagExcludeIP != "" {
-		if err := validateIPOrCIDR(flagExcludeIP); err != nil {
-			return f, fmt.Errorf("invalid --exclude-ip %q: %w", flagExcludeIP, err)
+		if err := validateIP(flagExcludeIP); err != nil {
+			return f, fmt.Errorf("--exclude-ip: %w", err)
 		}
 	}
 
 	return f, nil
-}
-
-// validateIPOrCIDR accepts a bare IP or a CIDR. Used to fail fast on a typo'd
-// --ip / --exclude-ip filter instead of silently returning "no log entries
-// found" when the CIDR fails to parse inside MatchEntry.
-func validateIPOrCIDR(s string) error {
-	if s == "" {
-		return nil
-	}
-	if strings.HasPrefix(s, "-") {
-		return fmt.Errorf("looks like a flag")
-	}
-	if net.ParseIP(s) != nil {
-		return nil
-	}
-	if _, _, err := net.ParseCIDR(s); err == nil {
-		return nil
-	}
-	return fmt.Errorf("not a valid IP or CIDR")
 }
 
 // parseSize parses a byte size. A bare integer is bytes. A suffix of k/kb, m/mb,


### PR DESCRIPTION
Closes #44

`validateIP` (`cmd/ip.go`) and `validateIPOrCIDR` (`cmd/root.go`) ran the same four checks in the same order. `validateIPOrCIDR` is gone; `validateIP` is the survivor, since it was the one with test coverage (`cmd/ip_test.go`, 28 cases).

### The one real difference, and why dropping it is safe

They disagreed on empty input: `validateIP("")` errored, `validateIPOrCIDR("")` returned `nil`. That branch was **unreachable** — both call sites already sit inside an `if flag != ""` guard:

```go
if flagIP != "" {
    if err := validateIPOrCIDR(flagIP); err != nil {
```

So an empty `--ip` never reached the function, and the guards stay exactly as they were. "Unset" is still not an error; it just never gets asked.

### Error messages

`validateIPOrCIDR` returned fragments (`"looks like a flag"`, `"not a valid IP or CIDR"`) because its caller prefixed the flag name and value; `validateIP` returned self-contained messages because its callers print `✗ %s: %v`. Keeping the self-contained form and trimming the value out of the caller's prefix avoids quoting it twice:

```console
$ caddy-analyze --ip 999.999.999.999 testdata/sample.log
Error: --ip: invalid IP or CIDR "999.999.999.999"     # exit 1

$ caddy-analyze --ip=-j testdata/sample.log
Error: --ip: invalid IP or CIDR "-j": looks like a flag   # exit 1
```

Both messages now say "IP or CIDR", which is what the function actually accepts — the old `invalid IP %q` from the block/unban path understated it.

`net` is no longer used in `cmd/root.go` and is dropped from its import block.

### Verification

```
go build ./... ; go vet ./...      # clean
go test ./...                      # all packages ok
gofmt -l cmd/ip.go cmd/root.go     # no output
```

Plus the four CLI paths above run against `testdata/sample.log`: bad IP, flag-like IP, bad `--exclude-ip`, and a valid `10.0.0.0/8` CIDR (still accepted, reaches the filter).