### PR TITLE
Show max-latency, size, level and ops-only filters

### DIFF
--- a/pkg/output/output.go
+++ b/pkg/output/output.go
@@ -164,6 +164,21 @@ func (r *Report) activeFilters() []string {
 	if r.filters.MinLatency > 0 {
 		f = append(f, "--slow "+fmt.Sprintf("%.0fms", r.filters.MinLatency*1000))
 	}
+	if r.filters.MaxLatency > 0 {
+		f = append(f, "--max-latency "+fmt.Sprintf("%.0fms", r.filters.MaxLatency*1000))
+	}
+	if r.filters.MinSize > 0 {
+		f = append(f, "--min-size "+FormatBytes(r.filters.MinSize))
+	}
+	if r.filters.MaxSize > 0 {
+		f = append(f, "--max-size "+FormatBytes(r.filters.MaxSize))
+	}
+	if len(r.filters.Level) > 0 {
+		f = append(f, "--level "+strings.Join(r.filters.Level, ","))
+	}
+	if r.filters.OpsOnly {
+		f = append(f, "--ops-only")
+	}
 	if r.filters.GrepPattern != "" {
 		f = append(f, "--grep "+r.filters.GrepPattern)
 	}

--- a/pkg/output/output_test.go
+++ b/pkg/output/output_test.go
@@ -315,3 +315,73 @@ func TestDefangDetectionMap(t *testing.T) {
 		t.Errorf("unexpected defanged record: %+v", v[0])
 	}
 }
+
+// TestActiveFiltersRendersEveryFilter pins that each filter field reaches the
+// "Filters:" header line. Five of them (--max-latency, --min-size, --max-size,
+// --level, --ops-only) used to be silently dropped, so a report produced with
+// them looked identical to one produced without.
+func TestActiveFiltersRendersEveryFilter(t *testing.T) {
+	tests := []struct {
+		name    string
+		filters types.Filters
+		want    string
+	}{
+		{"max-latency", types.Filters{MaxLatency: 1.5}, "--max-latency 1500ms"},
+		{"min-size", types.Filters{MinSize: 1024}, "--min-size 1.00 KB"},
+		{"max-size", types.Filters{MaxSize: 1048576}, "--max-size 1.00 MB"},
+		{"level single", types.Filters{Level: []string{"error"}}, "--level error"},
+		{"level repeated", types.Filters{Level: []string{"error", "warn"}}, "--level error,warn"},
+		{"ops-only", types.Filters{OpsOnly: true}, "--ops-only"},
+		// Regressions on the blocks that already worked.
+		{"slow", types.Filters{MinLatency: 0.5}, "--slow 500ms"},
+		{"grep", types.Filters{GrepPattern: "wp-admin"}, "--grep wp-admin"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := NewReport(analysis.New(types.Filters{}), FormatTable, 5)
+			r.SetFilters(tt.filters)
+			got := r.activeFilters()
+			for _, s := range got {
+				if s == tt.want {
+					return
+				}
+			}
+			t.Errorf("activeFilters() = %v, missing %q", got, tt.want)
+		})
+	}
+}
+
+// TestActiveFiltersZeroValuesAreOmitted guards the other direction: an unset
+// filter must not appear. --ops-only is a bool and the rest are compared
+// against zero, so a `>= 0` typo would print every flag on every report.
+func TestActiveFiltersZeroValuesAreOmitted(t *testing.T) {
+	r := NewReport(analysis.New(types.Filters{}), FormatTable, 5)
+	r.SetFilters(types.Filters{})
+	if got := r.activeFilters(); len(got) != 0 {
+		t.Errorf("activeFilters() on empty Filters = %v, want none", got)
+	}
+}
+
+// TestActiveFiltersCombined checks the five new blocks coexist with the old
+// ones in one report, which is how they are actually used.
+func TestActiveFiltersCombined(t *testing.T) {
+	r := NewReport(analysis.New(types.Filters{}), FormatTable, 5)
+	r.SetFilters(types.Filters{
+		MinLatency: 0.1,
+		MaxLatency: 1,
+		MinSize:    1024,
+		MaxSize:    1024 * 1024,
+		Level:      []string{"error", "warn"},
+		OpsOnly:    true,
+		Method:     "POST",
+	})
+	got := strings.Join(r.activeFilters(), ", ")
+	for _, want := range []string{
+		"--method POST", "--slow 100ms", "--max-latency 1000ms",
+		"--min-size 1.00 KB", "--max-size 1.00 MB", "--level error,warn", "--ops-only",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("activeFilters() = %q, missing %q", got, want)
+		}
+	}
+}


### PR DESCRIPTION
Closes #42

`activeFilters()` silently dropped five filters that change which entries the report is built from, so a run with them produced a header identical to a run without — the "Filters:" line understated what had been excluded.

Added, each next to its logical sibling:

| flag | field | rendered as |
| --- | --- | --- |
| `--max-latency` | `MaxLatency` | `--max-latency 1000ms` — same `%.0fms` form as `--slow`, which stores seconds too |
| `--min-size` | `MinSize` | `--min-size 1.00 KB` — via the existing `FormatBytes` |
| `--max-size` | `MaxSize` | `--max-size 1.00 MB` |
| `--level` | `Level` | `--level error,warn` — comma-joined, matching how `--status` renders its slice |
| `--ops-only` | `OpsOnly` | `--ops-only` — bare, matching `--errors-only` / `--no-bots` |

The issue also lists `--country` and `--asn`, but `types.Filters` has no such fields — `country`/`asn` are `top --by` dimensions, and entry-level country filtering is what #21 proposes. Nothing to render for those yet, so they are not in this diff.

### Before / after

```console
$ caddy-analyze -f csv --max-latency 1s --min-size 1kb --level error testdata/sample.log | grep filter
```

On `main` that prints nothing. On this branch:

```
filter,'--max-latency 1000ms
filter,'--min-size 1.00 KB
filter,'--level error
```

All three report paths pick this up, since they share `activeFilters()`: the table header (`output.go:388`), the JSON `filters` key (`:736`), and the CSV `filter` rows (`:835`), plus the HTML template.

### Tests

`activeFilters()` had no coverage, so three tests came with it:

- `TestActiveFiltersRendersEveryFilter` — the six new renderings, plus `--slow` and `--grep` as regressions on what already worked
- `TestActiveFiltersZeroValuesAreOmitted` — an empty `Filters` still yields an empty list, so a `>= 0` typo cannot print every flag on every report
- `TestActiveFiltersCombined` — the new blocks coexist with the old ones in one report

### Verification

```
go build ./... ; go vet ./... ; gofmt   # clean
go test ./...                            # all packages ok
```
