### PR TITLE
Document why formatDurationDelta keeps its own zero

### DIFF
--- a/cmd/diff.go
+++ b/cmd/diff.go
@@ -196,6 +196,14 @@ func formatDeltaFloat(d float64, unit string) string {
 	return fmt.Sprintf("0 %s", unit)
 }
 
+// formatDurationDelta renders a latency delta for the diff table.
+//
+// The zero case returns a literal "0ms" rather than output.FormatDuration(0),
+// which returns "N/A" for any non-positive input. "N/A" means "no data" --
+// the right thing when a run recorded no latency at all -- but a zero delta
+// means "no change", which is data. formatDelta and formatDeltaFloat above
+// take the same line, returning "0" and "0 <unit>"; all three leave the zero
+// unstyled so only a real movement is coloured.
 func formatDurationDelta(d float64) string {
 	durStr := output.FormatDuration(d)
 	if d > 0 {

--- a/cmd/diff_test.go
+++ b/cmd/diff_test.go
@@ -1,0 +1,96 @@
+package cmd
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/lenny-ts/caddy-analyzer/pkg/output"
+)
+
+// stripANSI removes the SGR sequences lipgloss adds so assertions can be made
+// on the text alone, whether or not the test process is attached to a TTY.
+func stripANSI(s string) string {
+	var b strings.Builder
+	for i := 0; i < len(s); {
+		if s[i] == 0x1b {
+			for i < len(s) && s[i] != 'm' {
+				i++
+			}
+			i++
+			continue
+		}
+		b.WriteByte(s[i])
+		i++
+	}
+	return b.String()
+}
+
+// TestFormatDurationDeltaZero pins the deliberate divergence from
+// output.FormatDuration: a zero delta is "no change", not "no data".
+func TestFormatDurationDeltaZero(t *testing.T) {
+	got := stripANSI(formatDurationDelta(0))
+	if got != "0ms" {
+		t.Errorf("formatDurationDelta(0) = %q, want %q", got, "0ms")
+	}
+	// The reason the literal exists: routing zero through FormatDuration
+	// would print "N/A", which reads as a missing measurement.
+	if na := output.FormatDuration(0); na != "N/A" {
+		t.Fatalf("output.FormatDuration(0) = %q, want %q — if this changed, "+
+			"revisit whether formatDurationDelta still needs its own zero case", na, "N/A")
+	}
+}
+
+// TestFormatDurationDeltaZeroMatchesSiblings pins that all three delta
+// formatters agree on an unstyled, literal zero.
+func TestFormatDurationDeltaZeroMatchesSiblings(t *testing.T) {
+	tests := []struct {
+		name string
+		got  string
+		want string
+	}{
+		{"formatDeltaInt", formatDeltaInt(0), "0"},
+		{"formatDeltaFloat", formatDeltaFloat(0, "req/s"), "0 req/s"},
+		{"formatDurationDelta", formatDurationDelta(0), "0ms"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.got != tt.want {
+				t.Errorf("%s zero case = %q, want %q (unstyled)", tt.name, tt.got, tt.want)
+			}
+		})
+	}
+}
+
+// TestFormatDurationDeltaSigned covers the non-zero branches: a slower run is
+// signed "+" and a faster one "-", and the magnitude is formatted by
+// FormatDuration in both directions.
+func TestFormatDurationDeltaSigned(t *testing.T) {
+	tests := []struct {
+		name string
+		in   float64
+		want string
+	}{
+		{"slower by 1ms", 0.001, "+1.00ms"},
+		{"slower by 1s", 1, "+1.00s"},
+		{"faster by 1ms", -0.001, "-1.00ms"},
+		{"faster by 1s", -1, "-1.00s"},
+		{"slower, sub-millisecond", 0.0000005, "+0\xc2\xb5s"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := stripANSI(formatDurationDelta(tt.in)); got != tt.want {
+				t.Errorf("formatDurationDelta(%v) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestFormatDurationDeltaNegativeIsNotNA guards the bug the "-" branch exists
+// to avoid: FormatDuration returns "N/A" for anything non-positive, so a
+// faster run must have its magnitude negated before formatting.
+func TestFormatDurationDeltaNegativeIsNotNA(t *testing.T) {
+	got := stripANSI(formatDurationDelta(-0.5))
+	if strings.Contains(got, "N/A") {
+		t.Errorf("formatDurationDelta(-0.5) = %q, want a signed duration, not N/A", got)
+	}
+}


### PR DESCRIPTION
Closes #45

The issue offers two routes — change `"0ms"` to `output.FormatDuration(0)`, or document the current behaviour and keep it. **Taking the second**, because the first would be a regression:

```go
func FormatDuration(d float64) string {
    if d <= 0 || d >= 1e18 {
        return "N/A"
    }
```

`FormatDuration(0)` returns `"N/A"`. That is right for its own callers — the `Avg Latency` columns either side of the delta, where a run that recorded no latency genuinely has no value. But in the delta column `"N/A"` reads as *no measurement*, when a zero delta is the opposite: two runs measured, and they matched. "The latency did not change" would be rendered as "we don't know the latency".

The two sibling formatters directly above it already take this line:

| function | zero case |
| --- | --- |
| `formatDeltaInt` | `"0"` |
| `formatDeltaFloat` | `"0 <unit>"` |
| `formatDurationDelta` | `"0ms"` |

All three return a plain literal and leave it unstyled, so only a real movement gets coloured. `"0ms"` is the consistent choice, not the odd one out — what was missing is any statement of *why*, which is what let it read as an oversight.

So this adds an eight-line comment saying it, and the tests to hold it.

### Tests — `cmd/diff_test.go` is new; these three formatters had no coverage

- `TestFormatDurationDeltaZero` — asserts `"0ms"`, **and** asserts `FormatDuration(0) == "N/A"` with a message pointing back here, so that if `FormatDuration` ever stops returning `"N/A"` the reason for the separate zero case gets re-examined rather than silently outliving it.
- `TestFormatDurationDeltaZeroMatchesSiblings` — the three zero cases agree on an unstyled literal.
- `TestFormatDurationDeltaSigned` — the `+`/`-` branches, in both directions, ms and s and sub-microsecond.
- `TestFormatDurationDeltaNegativeIsNotNA` — guards the bug the `-` branch exists to avoid: the magnitude must be negated before formatting, or a faster run prints `N/A`.

Assertions strip SGR sequences first (`stripANSI`), so they hold whether or not the test process has a TTY.

### Verification

```
go build ./... ; go vet ./...     # clean
go test ./...                      # all packages ok
gofmt -l cmd/diff.go cmd/diff_test.go   # no output
```

`cmd/diff.go` is comment-only, +8/-0; no behaviour changes.
