### PR TITLE
Extract emitReport closure in runFollowMode

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -549,6 +549,24 @@ func runFollowMode(ctx context.Context, sources []types.LogSource, filters types
 		windowStart = time.Now()
 	}
 
+	// emitReport finalizes the current window and prints it. It takes no
+	// arguments on purpose: resetEngine reassigns engine and opEngine, so a
+	// closure over the variables always reads whichever engine is live now.
+	// A print failure is reported and swallowed, as before, so one bad write
+	// does not end the follow session.
+	emitReport := func() {
+		engine.Finalize()
+		report := output.NewReportWithSections(engine, output.ParseFormat(flagFormat), flagTop, sections)
+		report.SetDetect(flagDetect)
+		report.SetDefang(flagDefang)
+		report.SetFilters(filters)
+		report.SetOperationalStats(opEngine.Stats())
+		report.SetWriter(w)
+		if err := report.Print(); err != nil {
+			fmt.Fprintf(os.Stderr, "write report: %v\n", err)
+		}
+	}
+
 	for line := range fanInFollow(ctx, sources) {
 		entry, err := parser.Parse(line)
 		if err != nil || entry == nil {
@@ -563,31 +581,13 @@ func runFollowMode(ctx context.Context, sources []types.LogSource, filters types
 			opEngine.Process(e)
 		}
 		if time.Since(last) > 5*time.Second {
-			engine.Finalize()
-			report := output.NewReportWithSections(engine, output.ParseFormat(flagFormat), flagTop, sections)
-			report.SetDetect(flagDetect)
-			report.SetDefang(flagDefang)
-			report.SetFilters(filters)
-			report.SetOperationalStats(opEngine.Stats())
-			report.SetWriter(w)
-			if err := report.Print(); err != nil {
-				fmt.Fprintf(os.Stderr, "write report: %v\n", err)
-			}
+			emitReport()
 			if time.Since(windowStart) > window {
 				resetEngine()
 			}
 			last = time.Now()
 		} else if time.Since(windowStart) > window {
-			engine.Finalize()
-			report := output.NewReportWithSections(engine, output.ParseFormat(flagFormat), flagTop, sections)
-			report.SetDetect(flagDetect)
-			report.SetDefang(flagDefang)
-			report.SetFilters(filters)
-			report.SetOperationalStats(opEngine.Stats())
-			report.SetWriter(w)
-			if err := report.Print(); err != nil {
-				fmt.Fprintf(os.Stderr, "write report: %v\n", err)
-			}
+			emitReport()
 			resetEngine()
 		}
 	}


### PR DESCRIPTION
Closes #46

The two report-emission blocks in `runFollowMode` were byte-identical — ten lines each, `Finalize` → `NewReportWithSections` → five setters → `Print`. Both are now `emitReport()`.

Net: **+20 / -20**, and the loop body reads as the two policies it actually encodes:

```go
if time.Since(last) > 5*time.Second {
    emitReport()
    if time.Since(windowStart) > window {
        resetEngine()
    }
    last = time.Now()
} else if time.Since(windowStart) > window {
    emitReport()
    resetEngine()
}
```

### One deliberate difference from `reportFn`

The issue points at `runIntervalMode`'s `reportFn` as the model. That one takes `(engine, opEngine, time)` and returns `error`; `emitReport` takes nothing and returns nothing, for two reasons specific to this function:

- **No parameters.** `resetEngine` *reassigns* `engine` and `opEngine`, so they must be read at call time, not captured at definition time. Closing over the variables does exactly that — the same thing `resetEngine` itself relies on. Passing them in would work today but would silently pin the wrong engine the moment a caller was added before a reset.
- **No error return.** Both call sites already logged-and-continued rather than returning; `runIntervalMode` genuinely aborts on a write error, `runFollowMode` deliberately does not, because a follow session should survive one bad write. Returning an error here would invite a caller to change that by accident.

Both are stated in a comment on the closure.

### Verification

```
go build ./... ; go vet ./... ; gofmt -l cmd/root.go   # clean
go test ./...                                           # all packages ok
```

Live follow run, `caddy-analyze -F` against a file appended to twice across the 5s emit boundary: reports emitted, 82 lines, same sections as `main`.

**One thing the comparison turned up, unrelated to this PR:** diffing `main`'s follow output against itself across two runs is *already* not stable — entries tied on the same count come out in a different order each time (Go map iteration in the top-N ranking). So the before/after outputs here differ in tie order too, but `main` differs from itself identically. Worth its own issue if deterministic top-N output matters for the `diff` subcommand; happy to open one.
