### PR TITLE
Add country and asn to every dimension help list

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -87,7 +87,7 @@ Sources:
 
 Subcommands:
   tail [source...]       Colorized real-time log viewer
-  top <dimension>        Quick top-N metric inspector (path, ip, ua, status, method, host, bandwidth)
+  top <dimension>        Quick top-N metric inspector (path, ip, ua, status, method, host, bandwidth, country, asn)
   diff <log1> <log2>     Compare two log files for RPS shifts, 5xx spikes, and latency changes
 
 Filtering (activate colored log listing instead of report):
@@ -115,6 +115,7 @@ Examples:
   caddy-analyze --ip 10.0.0.0/8 access.log
   caddy-analyze --5xx --no-bots access.log
   caddy-analyze tail --ip 192.168.1.100 docker://caddy
+  caddy-analyze tail --detect docker://caddy
   caddy-analyze top ip --5xx -t 20 access.log
   caddy-analyze diff base.log current.log
 `,

--- a/cmd/top.go
+++ b/cmd/top.go
@@ -40,7 +40,7 @@ Dimensions:
 
 Useful Flags:
   -t, --top <N>      Number of top entries to display (default: 10)
-  -b, --by <dim>     Specify dimension via flag (path, ip, ua, status, method, host, bandwidth)
+  -b, --by <dim>     Specify dimension via flag (path, ip, ua, status, method, host, bandwidth, country, asn)
   --5xx              Filter only 5xx server error requests
   --slow <duration>  Filter requests taking longer than duration (e.g. 500ms, 1s)
   --no-bots          Exclude search engine crawlers and automated bots
@@ -59,7 +59,7 @@ Examples:
 }
 
 func init() {
-	topCmd.Flags().StringVarP(&flagTopBy, "by", "b", "", "Dimension to group by (path, ip, ua, status, method, host, bandwidth)")
+	topCmd.Flags().StringVarP(&flagTopBy, "by", "b", "", "Dimension to group by (path, ip, ua, status, method, host, bandwidth, country, asn)")
 	rootCmd.AddCommand(topCmd)
 }
 
@@ -132,7 +132,7 @@ func runTopCmd(cmd *cobra.Command, args []string) error {
 
 	dim := strings.ToLower(dimension)
 	if _, ok := topFieldForDimension(dim); !ok {
-		return fmt.Errorf("unknown dimension: %s (supported: path, ip, ua, status, method, host, bandwidth)", dim)
+		return fmt.Errorf("unknown dimension: %s (supported: path, ip, ua, status, method, host, bandwidth, country, asn)", dim)
 	}
 
 	var w io.Writer = os.Stdout


### PR DESCRIPTION
Closes #39
Closes #40
Closes #41

Three help-text issues in one PR — they are four one-line edits across two files, and splitting them into three branches would put three near-identical diffs in your queue. Say the word and I will split them.

`country` and `asn` have been fully working `top` dimensions since v0.4.0 (`topFieldForDimension`, `cmd/top.go:198-201`, and the `Long` help block at `cmd/top.go:38-39` documents them), but three of the four places that enumerate dimensions still stopped at `bandwidth` — so `--help` and the error a user gets after a typo both denied the feature exists.

| # | location | was |
| --- | --- | --- |
| #40 | `cmd/root.go` — root `Long`, `top <dimension>` line | stopped at `bandwidth` |
| #39 | `cmd/top.go` — `--by <dim>` in the `Long` block | stopped at `bandwidth` |
| #39 | `cmd/top.go` — the `--by` flag's registered help string | stopped at `bandwidth` |
| #39 | `cmd/top.go` — `unknown dimension` error | stopped at `bandwidth` |
| #41 | `cmd/root.go` — root `Examples` | no `tail --detect` example |

All four lists now read `path, ip, ua, status, method, host, bandwidth, country, asn` — appending rather than inserting, so the order matches the existing `Long` block in `top.go`, which already listed `country` and `asn` after `bandwidth`.

Nine names, matching the nine canonical cases in `topFieldForDimension`. Its aliases (`paths`, `ips`, `useragent`, `user-agent`, `methods`, `hosts`, `countries`, `bytes`) stay out of the help lists, as they were.

### Verified against the built binary

```console
$ caddy-analyze --help | grep 'top <dimension>'
  top <dimension>        Quick top-N metric inspector (path, ip, ua, status, method, host, bandwidth, country, asn)

$ caddy-analyze --help | grep 'tail --detect'
  caddy-analyze tail --detect docker://caddy

$ caddy-analyze top --help | grep 'by string'
  -b, --by string   Dimension to group by (path, ip, ua, status, method, host, bandwidth, country, asn)

$ caddy-analyze top --by nope testdata/sample.log
Error: unknown dimension: nope (supported: path, ip, ua, status, method, host, bandwidth, country, asn)
```

And the two newly-advertised dimensions do resolve, so the help is not now promising something that fails:

```console
$ caddy-analyze top country testdata/sample.log   # -> "Top Countries:"
$ caddy-analyze top asn testdata/sample.log       # -> "Top Autonomous Systems:"
```

(Both need a GeoIP mmdb to produce rows, as the `Long` block already says.)

### Verification

```
go build ./... ; go vet ./... ; gofmt -l cmd/root.go cmd/top.go   # clean
go test ./...                                                      # all packages ok
```
