### PR TITLE
SHA-pin the six tag-pinned third-party actions

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -22,16 +22,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
       - name: Setup Pages
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5.0.0
 
       - name: Upload Artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3.0.1
         with:
           path: 'docs'
 
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4.0.5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,7 +38,7 @@ jobs:
         uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0
 
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v6
+        uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # v6.4.0
         with:
           distribution: goreleaser
           version: "~> v2"
@@ -58,7 +58,7 @@ jobs:
             checksums.txt
 
       - name: Upload SBOM and signatures
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2.6.2
         with:
           files: |
             dist/*.spdx.json


### PR DESCRIPTION
Closes #24

All six tag-pinned actions are now SHA-pinned. `grep -rn "uses:.*@v[0-9]" .github/workflows/` returns nothing — every action in the repo is pinned by digest.

### `docs.yml`

```yaml
actions/checkout@11d5960a326750d5838078e36cf38b85af677262            # v4.4.0
actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b     # v5.0.0
actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3.0.1
actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e        # v4.0.5
```

### `release.yml`

```yaml
goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # v6.4.0
softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65  # v2.6.2
```

## Comments name the concrete release, not the major tag

The issue's example uses `# v4`, but the existing pins in `ci.yml` and `release.yml` say `# v7.0.1` and `# v7.0.0`. I followed the existing style: each comment names the **exact release** the SHA is, resolved from the tag list rather than assumed. `# v4` would be true today and still true after the maintainer moves `v4` — which is the mutability the pinning is meant to remove, reintroduced in the one part a human actually reads.

## Every SHA verified to resolve

Each pin was checked against the GitHub API, not just pasted:

```
commit      actions/checkout@11d5960a3267
commit      actions/configure-pages@983d7736d9b0
commit      actions/upload-pages-artifact@56afc609e742
commit      actions/deploy-pages@d6db90164ac5
commit      goreleaser/goreleaser-action@e435ccd77726
commit      softprops/action-gh-release@3bb12739c298
```

I ran the same check over the pins that were **already** in the tree, and two came back unresolved at first: `golangci/golangci-lint-action@d583c34f…` and `sigstore/cosign-installer@f713795c…`.

They are fine — and worth writing down, because it looks alarming. Those two are pinned to the **annotated tag object** SHA rather than the commit SHA (`d583c34f…` is the `v9.3.0` tag object; the commit is `ba0d7d2e…`). `repos/…/commits/{sha}` 422s on a tag object, so a naive check calls it broken. Actions resolves both, and a tag object SHA is content-addressed and therefore just as immutable — so there is nothing to fix. I confirmed the `golangci-lint` job is green on `main` before concluding that rather than filing a false alarm.

My six are pinned to commit SHAs, which is the more common convention and matches the majority of the existing pins.

## One thing left deliberately alone

`docs.yml` uses `actions/checkout@v4` while `ci.yml` and `release.yml` use `v7.0.1`. I pinned v4 **as it stands** rather than bumping it — the issue asks to resolve the SHA the current tag points at, and a major-version upgrade is a different change with its own risk. Happy to send that separately if you want the three workflows on one version.

## Verification

```
grep -rn "uses:.*@v[0-9]" .github/workflows/   # no output
python -c "yaml.safe_load(...)"                # all three workflows parse
```

Diff is 6 lines across 2 files; no job, step, or ordering changes.
