### PR TITLE
Add tail --detect example to root help text

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -115,6 +115,7 @@ Examples:
   caddy-analyze --ip 10.0.0.0/8 access.log
   caddy-analyze --5xx --no-bots access.log
   caddy-analyze tail --ip 192.168.1.100 docker://caddy
+  caddy-analyze tail --detect docker://caddy
   caddy-analyze top ip --5xx -t 20 access.log
   caddy-analyze diff base.log current.log
 `,


### PR DESCRIPTION
Closes #41

Adds the missing line to the `Examples:` block in `cmd/root.go`, next to the existing `tail` example.

Verified from a build of this branch:

```
Examples:
  caddy-analyze /var/log/caddy/access.log
  caddy-analyze --detect /var/log/caddy/access.log
  caddy-analyze --ip 10.0.0.0/8 access.log
  caddy-analyze --5xx --no-bots access.log
  caddy-analyze tail --ip 192.168.1.100 docker://caddy
  caddy-analyze tail --detect docker://caddy
  caddy-analyze top ip --5xx -t 20 access.log
  caddy-analyze diff base.log current.log
```

Placed directly after the other `tail` line so the two `tail` forms read together, and it keeps the block's existing shape: simplest invocation first, then the flag variants.

`go vet ./...` clean, `go test ./...` all packages pass.
