### PR TITLE
Defang only IPv4 addresses and URL hostnames

### DIFF
--- a/pkg/output/defang.go
+++ b/pkg/output/defang.go
@@ -1,14 +1,39 @@
 package output
 
-import "strings"
+import (
+	"regexp"
+	"strings"
+)
 
-// Defang replaces dots with [.] and URL schemes with hxxp[s]:// in a string
-// to prevent accidental clicks in shared reports.
+var (
+	bareIPv4Pattern    = regexp.MustCompile(`\b(\d{1,3}\.){3}\d{1,3}\b`)
+	urlHostnamePattern = regexp.MustCompile(`://([a-zA-Z0-9-]+\.)+[a-zA-Z]{2,}`)
+)
+
+// Defang replaces dots in IPv4 addresses and URL hostnames with [.] and
+// URL schemes with hxxp[s]:// to prevent accidental clicks in shared reports.
 // Example: http://185.220.101.42 → hxxp://185[.]220[.]101[.]42
 func Defang(s string) string {
+	s = defangSchemes(s)
+	s = defangIPv4(s)
+	return defangURLHostnames(s)
+}
+
+func defangSchemes(s string) string {
 	s = strings.ReplaceAll(s, "https://", "hxxps://")
-	s = strings.ReplaceAll(s, "http://", "hxxp://")
-	return strings.ReplaceAll(s, ".", "[.]")
+	return strings.ReplaceAll(s, "http://", "hxxp://")
+}
+
+func defangIPv4(s string) string {
+	return bareIPv4Pattern.ReplaceAllStringFunc(s, func(ip string) string {
+		return strings.ReplaceAll(ip, ".", "[.]")
+	})
+}
+
+func defangURLHostnames(s string) string {
+	return urlHostnamePattern.ReplaceAllStringFunc(s, func(urlHost string) string {
+		return strings.ReplaceAll(urlHost, ".", "[.]")
+	})
 }
 
 // DefangIP is a convenience wrapper for defanging a bare IP address.

--- a/pkg/output/defang.go
+++ b/pkg/output/defang.go
@@ -1,12 +1,13 @@
 package output
 
 import (
+	"net/netip"
 	"regexp"
 	"strings"
 )
 
 var (
-	bareIPv4Pattern    = regexp.MustCompile(`\b(\d{1,3}\.){3}\d{1,3}\b`)
+	dottedTokenPattern = regexp.MustCompile(`[A-Za-z0-9_]+(?:\.[A-Za-z0-9_]+)+`)
 	urlHostnamePattern = regexp.MustCompile(`://([a-zA-Z0-9-]+\.)+[a-zA-Z]{2,}`)
 )
 
@@ -25,8 +26,13 @@ func defangSchemes(s string) string {
 }
 
 func defangIPv4(s string) string {
-	return bareIPv4Pattern.ReplaceAllStringFunc(s, func(ip string) string {
-		return strings.ReplaceAll(ip, ".", "[.]")
+	return dottedTokenPattern.ReplaceAllStringFunc(s, func(candidate string) string {
+		addr, err := netip.ParseAddr(candidate)
+		if err != nil || !addr.Is4() {
+			return candidate
+		}
+
+		return strings.ReplaceAll(candidate, ".", "[.]")
 	})
 }
 

--- a/pkg/output/defang_test.go
+++ b/pkg/output/defang_test.go
@@ -9,7 +9,12 @@ func TestDefang(t *testing.T) {
 		{"185.220.101.42", "185[.]220[.]101[.]42"},
 		{"https://evil.com", "hxxps://evil[.]com"},
 		{"http://169.254.169.254/", "hxxp://169[.]254[.]169[.]254/"},
+		{"http://evil.com/path?q=1.2.3", "hxxp://evil[.]com/path?q=1.2.3"},
 		{"192.168.1.1:8080", "192[.]168[.]1[.]1:8080"},
+		{"Caddy/2.7.4", "Caddy/2.7.4"},
+		{"/api/v2.1/users", "/api/v2.1/users"},
+		{"evil.com", "evil.com"},
+		{"2001:db8::1", "2001:db8::1"},
 		{"", ""},
 		{"no-dots-here", "no-dots-here"},
 	}
@@ -21,9 +26,15 @@ func TestDefang(t *testing.T) {
 }
 
 func TestDefangIP(t *testing.T) {
-	got := DefangIP("10.0.0.1")
-	want := "10[.]0[.]0[.]1"
-	if got != want {
-		t.Errorf("DefangIP = %q, want %q", got, want)
+	tests := []struct {
+		in, want string
+	}{
+		{"10.0.0.1", "10[.]0[.]0[.]1"},
+		{"2001:db8::1", "2001:db8::1"},
+	}
+	for _, tt := range tests {
+		if got := DefangIP(tt.in); got != tt.want {
+			t.Errorf("DefangIP(%q) = %q, want %q", tt.in, got, tt.want)
+		}
 	}
 }

--- a/pkg/output/defang_test.go
+++ b/pkg/output/defang_test.go
@@ -25,6 +25,35 @@ func TestDefang(t *testing.T) {
 	}
 }
 
+func TestDefangIPv4Validation(t *testing.T) {
+	tests := []struct {
+		name, in, want string
+	}{
+		{"lowest valid address", "0.0.0.0", "0[.]0[.]0[.]0"},
+		{"highest valid address", "255.255.255.255", "255[.]255[.]255[.]255"},
+		{"octets above 255", "999.999.999.999", "999.999.999.999"},
+		{"last octet above 255", "192.168.1.256", "192.168.1.256"},
+		{"octets with leading zeroes", "010.000.015.001", "010.000.015.001"},
+		{"five component dotted sequence", "1.2.3.4.5", "1.2.3.4.5"},
+		{"version prefix", "v1.2.3.4", "v1.2.3.4"},
+		{"version suffix", "1.2.3.4beta", "1.2.3.4beta"},
+		{"version in URL path", "https://example.com/releases/1.2.3.4.5", "hxxps://example[.]com/releases/1.2.3.4.5"},
+		{"valid address in URL with port and path", "http://192.0.2.1:8080/admin", "hxxp://192[.]0[.]2[.]1:8080/admin"},
+		{"invalid address in URL", "http://999.999.999.999/path", "hxxp://999.999.999.999/path"},
+		{"valid addresses next to punctuation", "client=(192.0.2.1); upstream=198.51.100.255:443", "client=(192[.]0[.]2[.]1); upstream=198[.]51[.]100[.]255:443"},
+		{"invalid candidate followed by valid address", "invalid=999.999.999.999, valid=203.0.113.5", "invalid=999.999.999.999, valid=203[.]0[.]113[.]5"},
+		{"address before sentence punctuation", "Observed 192.0.2.1.", "Observed 192[.]0[.]2[.]1."},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := Defang(tt.in); got != tt.want {
+				t.Errorf("Defang(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestDefangIP(t *testing.T) {
 	tests := []struct {
 		in, want string


### PR DESCRIPTION
## Summary

- replace blanket dot substitution with focused IPv4 and URL-hostname defanging
- keep URL scheme defanging while preserving version numbers, paths, queries, bare domains, and IPv6
- retain the public `Defang` and `DefangIP` APIs
- add regression coverage for the behavior confirmed in #63

## Validation

- focused regression test: failed before the implementation and passes after it
- `go test ./pkg/output`: passed
- `go test -count=1 -coverprofile=coverage.out ./pkg/output`: passed (60.3%)
- `go vet ./...`: passed
- `go build ./...`: passed
- `gofmt -l` and `git diff --check`: passed

The full local `go test ./...` run did not complete in this Windows sandbox after `cmd.test` stopped making progress, and `-race` requires CGO, which is unavailable here. Project CI can provide those platform checks.

Fixes #63
